### PR TITLE
Manage version and gem push all master commits

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
+deployment:
+  rubygems:
+    branch: kmonihen
+    commands:
+      - git status
+      - ./publish.sh
 machine:
   timezone:
     America/New_York

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ deployment:
     branch: kmonihen
     commands:
       - git status
-      - ./publish.sh
+      - bash ./publish.sh
 machine:
   timezone:
     America/New_York

--- a/crossing.gemspec
+++ b/crossing.gemspec
@@ -7,7 +7,7 @@ spec = Gem::Specification.new do |s|
   s.name          = 'crossing'
   s.executables  << 'crossing'
   s.license       = 'MIT'
-  s.version       = '0.0.4'
+  s.version       = '0.0.0'
   s.author        = ['John Ulick', 'Jonny Sywulak', 'Stelligent']
   s.email         = 'info@stelligent.com'
   s.homepage      = 'http://www.stelligent.com'

--- a/publish.sh
+++ b/publish.sh
@@ -48,8 +48,8 @@ gem build crossing.gemspec
 if [[ ${CIRCLE_BRANCH} == "master" ]];
         then
                 echo "Pushing gem from master!"
-                #gem push crossing-*.gem
-                #git push --tags
+                gem push crossing-*.gem
+                git push --tags
                 exit 0
         else
                 echo "Not in master, skipping gem push!"

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,65 @@
+#!/bin/bash -ex
+set -o pipefail
+
+#
+# Set the API key gem credentials
+#
+set +x
+if [[ -z ${rubygems_api_key} ]];
+then
+  echo "rubygems_api_key must be set in the environment"
+  exit 1
+fi
+set -x
+
+set +ex
+echo :rubygems_api_key: ${rubygems_api_key} > ~/.gem/credentials
+set -ex
+chmod 0600 ~/.gem/credentials
+
+git config --global user.email "build@build.com"
+git config --global user.name "build"
+
+#versioning?
+#current_version=$(ruby -e 'tags=`git tag -l v0\.3\.*`' \
+#                       -e 'p tags.lines.map { |tag| tag.sub(/v0.3./, "").chomp.to_i }.max')
+
+#if [[ ${current_version} == nil ]];
+#then
+#  new_version='0.3.0'
+#else
+#  new_version=0.3.$((current_version+1))
+#fi
+
+#sed -i "s/0\.0\.0/${new_version}/g" crossing.gemspec
+
+#on circle ci - head is ambiguous for reasons that i don't grok
+#we haven't made the new tag and we can't if we are going to annotate
+#head=$(git log -n 1 --oneline | awk '{print $1}')
+
+#issue_prefix='^#'
+#echo "Remember! You need to start your commit messages with #{issue_prefix}x, where x is the issue number your commit resolves."
+
+#if [[ ${current_version} == nil ]];
+#then
+#  log_rev_range=${head}
+#else
+#  log_rev_range="v0.3.${current_version}..${head}"
+#fi
+
+#issues=$(git log ${log_rev_range} --oneline | awk '{print $2}' | grep "${issue_prefix}" | uniq)
+
+#git tag -a v${new_version} -m "${new_version}" -m "Issues with commits, not necessarily closed: ${issues}"
+
+#git push --tags
+
+#check CIRCLE_BRANCH is master before pushing gem
+if [[ ${CIRCLE_BRANCH} == "master" ]];
+	then
+		echo "Building and pushing gem!"
+		#gem build crossing.gemspec
+		#gem push crossing-*.gem
+	else
+		echo "Not in master, skipping gem build"
+		exit 1
+		

--- a/publish.sh
+++ b/publish.sh
@@ -59,7 +59,8 @@ if [[ ${CIRCLE_BRANCH} == "master" ]];
 		echo "Building and pushing gem!"
 		#gem build crossing.gemspec
 		#gem push crossing-*.gem
-		exit 1;
+		exit 0
 	else
 		echo "Not in master, skipping gem build"
-		exit 1;
+		exit 0
+fi

--- a/publish.sh
+++ b/publish.sh
@@ -59,7 +59,7 @@ if [[ ${CIRCLE_BRANCH} == "master" ]];
 		echo "Building and pushing gem!"
 		#gem build crossing.gemspec
 		#gem push crossing-*.gem
+		exit 1;
 	else
 		echo "Not in master, skipping gem build"
-		exit 1
-		
+		exit 1;

--- a/publish.sh
+++ b/publish.sh
@@ -20,47 +20,38 @@ chmod 0600 ~/.gem/credentials
 git config --global user.email "build@build.com"
 git config --global user.name "build"
 
-#versioning?
-#current_version=$(ruby -e 'tags=`git tag -l v0\.3\.*`' \
-#                       -e 'p tags.lines.map { |tag| tag.sub(/v0.3./, "").chomp.to_i }.max')
+#
+# Pull current version number from the git tags
+#
+current_version=$(ruby -e 'tags=`git tag -l v0\.0\.*`' \
+                       -e 'p tags.lines.map { |tag| tag.sub(/v0.0./, "").chomp.to_i }.max')
 
-#if [[ ${current_version} == nil ]];
-#then
-#  new_version='0.3.0'
-#else
-#  new_version=0.3.$((current_version+1))
-#fi
+#
+# Increment the version number, update the gemspect and add version tag to git
+#
+if [[ ${current_version} == nil ]];
+then
+  new_version='0.1.0'
+else
+  new_version=0.0.$((current_version+1))
+fi
 
-#sed -i "s/0\.0\.0/${new_version}/g" crossing.gemspec
+sed -i "s/0\.0\.0/${new_version}/g" crossing.gemspec
 
-#on circle ci - head is ambiguous for reasons that i don't grok
-#we haven't made the new tag and we can't if we are going to annotate
-#head=$(git log -n 1 --oneline | awk '{print $1}')
+git tag -a v${new_version} -m "${new_version}"
 
-#issue_prefix='^#'
-#echo "Remember! You need to start your commit messages with #{issue_prefix}x, where x is the issue number your commit resolves."
+#
+# Build gem then check CIRCLE_BRANCH is master before pushing
+#
+gem build crossing.gemspec
 
-#if [[ ${current_version} == nil ]];
-#then
-#  log_rev_range=${head}
-#else
-#  log_rev_range="v0.3.${current_version}..${head}"
-#fi
-
-#issues=$(git log ${log_rev_range} --oneline | awk '{print $2}' | grep "${issue_prefix}" | uniq)
-
-#git tag -a v${new_version} -m "${new_version}" -m "Issues with commits, not necessarily closed: ${issues}"
-
-#git push --tags
-
-#check CIRCLE_BRANCH is master before pushing gem
 if [[ ${CIRCLE_BRANCH} == "master" ]];
-	then
-		echo "Building and pushing gem!"
-		#gem build crossing.gemspec
-		#gem push crossing-*.gem
-		exit 0
-	else
-		echo "Not in master, skipping gem build"
-		exit 0
+        then
+                echo "Pushing gem from master!"
+                #gem push crossing-*.gem
+                #git push --tags
+                exit 0
+        else
+                echo "Not in master, skipping gem push!"
+                exit 0
 fi


### PR DESCRIPTION
I added publish.sh to manage the crossing version from git tags and increment the version. Commits to master will now push the built gem and updated tags to git.

If this is merged with master the circle.yml needs the branch name updated to "master".

The gemspec version changed to 0.0.0 so it can be replaced with the incremented version from git tags before it's built.